### PR TITLE
Add support for whatsapp business templates api

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -41,7 +41,8 @@ export default defineConfig({
         text: 'Templates',
         items: [
           { text: 'Text', link: '/templates/text' },
-          { text: 'Media', link: '/templates/media' }
+          { text: 'Media', link: '/templates/media' },
+          { text: 'Get', link: '/templates/get' }
         ]
       },
       {

--- a/docs/src/templates/get.md
+++ b/docs/src/templates/get.md
@@ -1,0 +1,77 @@
+# Get Templates
+
+[<Badge type="tip" text="api docs" />](https://developers.facebook.com/docs/whatsapp/business-management-api/message-templates)
+
+The `getTemplates` function allows you to retrieve a list of message templates from the WhatsApp Cloud API.
+
+```ts
+async function getTemplates({
+  fields,
+  limit,
+  after,
+  before,
+  config,
+}: {
+  fields?: templateFields[];
+  limit?: number;
+  after?: string;
+  before?: string;
+  config?: WsConfig;
+} = {}): Promise<Templates>;
+```
+
+## Parameters:
+
+- `fields`: Optional array of fields to include in the response.
+- `limit`: Optional limit on the number of templates to retrieve.
+- `after`: Optional cursor for pagination to retrieve templates after a specific point.
+- `before`: Optional cursor for pagination to retrieve templates before a specific point.
+- `config`: Optional configuration settings.
+
+## Return
+
+- **Templates**: An array of message templates.
+
+## Example usage
+
+### Retrieve all templates
+
+```ts
+import { getTemplates } from 'ws-cloud-api/templates'
+
+getTemplates()
+  .then((templates) => {
+    console.log('Templates retrieved:', templates)
+  })
+  .catch(console.error)
+```
+
+### Retrieve templates with specific fields and limit
+
+```ts
+import { getTemplates } from 'ws-cloud-api/templates'
+
+getTemplates({
+  fields: ['name', 'language'],
+  limit: 10,
+})
+  .then((templates) => {
+    console.log('Templates retrieved:', templates)
+  })
+  .catch(console.error)
+```
+
+### Retrieve templates with pagination
+
+```ts
+import { getTemplates } from 'ws-cloud-api/templates'
+
+const page1 = await getTemplates({ limit: 2 })
+console.log('page1', page1)
+
+const page2 = await getTemplates({
+  limit: 2,
+  after: page1.paging.cursors.after
+})
+console.log('page2', page2)
+```

--- a/ws-cloud-api/.env.example
+++ b/ws-cloud-api/.env.example
@@ -1,6 +1,7 @@
 # Messaging API
 WS_CA_VERSION='19.0'
 WS_PHONE_NUMBER_ID=
+WS_BUSINESS_ID=
 WS_TOKEN=
 
 # Webhook

--- a/ws-cloud-api/package.json
+++ b/ws-cloud-api/package.json
@@ -17,7 +17,7 @@
     "build": "unbuild",
     "test:messages": "jiti ./src/test/sendMessages.ts",
     "test:webhook": "jiti ./src/test/webhook.ts",
-    "test:templates": "jiti ./src/test/sendTemplates.ts",
+    "test:templates": "jiti ./src/test/templates.ts",
     "test:media": "jiti ./src/test/media.ts",
     "lint": "eslint \"./src/**/*.ts\" && tsc --noEmit"
   },

--- a/ws-cloud-api/src/base.ts
+++ b/ws-cloud-api/src/base.ts
@@ -34,6 +34,21 @@ export async function sendRequest ({
 
   const requestId = id === 'phoneNumberId' ? phoneNumberId : businessId
 
+  // Check config
+  if (requestId === undefined) {
+    return {
+      success: false,
+      error: 'Missing request ID'
+    }
+  }
+
+  if (token === undefined) {
+    return {
+      success: false,
+      error: 'Missing token'
+    }
+  }
+
   const response = await fetch(
     `https://graph.facebook.com/v${apiVersion}/${requestId}/${path}${query !== undefined ? `?${query}` : ''}`,
     {
@@ -49,7 +64,7 @@ export async function sendRequest ({
   if (!response.ok) {
     return {
       success: false,
-      error: response.statusText
+      error: response
     }
   }
 

--- a/ws-cloud-api/src/base.ts
+++ b/ws-cloud-api/src/base.ts
@@ -1,0 +1,60 @@
+import type { WsConfig } from './types/config'
+
+export async function sendRequest ({
+  id,
+  body,
+  path,
+  query,
+  method,
+  config
+}: {
+  id: 'phoneNumberId' | 'businessId'
+  body?: string
+  path: 'messages' | 'message_templates' | string & NonNullable<unknown>
+  query?: string
+  method: 'POST' | 'GET' | 'DELETE' | 'PUT' | 'PATCH' | 'OPTIONS' | 'HEAD' | 'CONNECT' | 'TRACE' | string & NonNullable<unknown>
+  config?: WsConfig
+}): Promise<
+  | { success: true, response: unknown }
+  | { success: false, error: unknown }
+  > {
+  // Config
+  const apiVersion = typeof process !== 'undefined'
+    ? process.env.WS_CA_VERSION ?? config?.apiVersion ?? '20.0'
+    : config?.apiVersion ?? '20.0'
+  const phoneNumberId = typeof process !== 'undefined'
+    ? process.env.WS_PHONE_NUMBER_ID ?? config?.phoneNumberId
+    : config?.phoneNumberId
+  const businessId = typeof process !== 'undefined'
+    ? process.env.WS_BUSINESS_ID ?? config?.businessId
+    : config?.businessId
+  const token = typeof process !== 'undefined'
+    ? process.env.WS_TOKEN ?? config?.token
+    : config?.token
+
+  const requestId = id === 'phoneNumberId' ? phoneNumberId : businessId
+
+  const response = await fetch(
+    `https://graph.facebook.com/v${apiVersion}/${requestId}/${path}${query !== undefined ? `?${query}` : ''}`,
+    {
+      method,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json'
+      },
+      body
+    }
+  )
+
+  if (!response.ok) {
+    return {
+      success: false,
+      error: response.statusText
+    }
+  }
+
+  return {
+    success: true,
+    response: await response.json()
+  }
+}

--- a/ws-cloud-api/src/messaging.ts
+++ b/ws-cloud-api/src/messaging.ts
@@ -1,3 +1,4 @@
+import { sendRequest } from './base'
 import { uploadMedia } from './media'
 import { type WsConfig } from './types/config'
 import { InteractiveTypes, MessageTypes } from './types/enums'
@@ -29,32 +30,17 @@ export async function sendMessageRequest ({
     ...body
   })
 
-  // Config
-  const apiVersion = typeof process !== 'undefined'
-    ? process.env.WS_CA_VERSION ?? config?.apiVersion ?? '19.0'
-    : config?.apiVersion ?? '19.0'
-  const phoneNumberId = typeof process !== 'undefined'
-    ? process.env.WS_PHONE_NUMBER_ID ?? config?.phoneNumberId
-    : config?.phoneNumberId
-  const token = typeof process !== 'undefined'
-    ? process.env.WS_TOKEN ?? config?.token
-    : config?.token
+  const requestResponse = await sendRequest({
+    id: 'phoneNumberId',
+    body: postBody,
+    path: 'messages',
+    method: 'POST',
+    config
+  })
 
-  const response = await fetch(
-    `https://graph.facebook.com/v${apiVersion}/${phoneNumberId}/messages`,
-    {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/json'
-      },
-      body: postBody
-    }
-  )
-
-  if (!response.ok) {
+  if (!requestResponse.success) {
     console.error(`Failed to send ${body.type} message`)
-    console.error(JSON.stringify(await response.json(), null, 2))
+    console.error(JSON.stringify(await requestResponse.error, null, 2))
     return false
   } else {
     return true

--- a/ws-cloud-api/src/templates.ts
+++ b/ws-cloud-api/src/templates.ts
@@ -109,18 +109,26 @@ export async function sendTemplateRequest ({
 export async function getTemplates ({
   fields,
   limit,
+  after,
+  before,
   config
 }: {
   fields?: templateFields[]
   limit?: number
+  after?: string
+  before?: string
   config?: WsConfig
 } = {}): Promise<Templates> {
   const queryParams: {
     fields?: string
     limit?: string
+    after?: string
+    before?: string
   } = {}
   if (fields !== undefined) queryParams.fields = fields.join(',')
   if (limit !== undefined) queryParams.limit = limit.toString()
+  if (after !== undefined) queryParams.after = after
+  if (before !== undefined) queryParams.before = before
   return (await sendTemplateRequest({
     query: new URLSearchParams(queryParams).toString(),
     config

--- a/ws-cloud-api/src/templates.ts
+++ b/ws-cloud-api/src/templates.ts
@@ -6,7 +6,7 @@ import type {
   TemplateHeaderParameter
 } from './types/messages'
 import { sendRequest } from './base'
-import type { templateFields } from './types/templates'
+import type { templateFields, Templates } from './types/templates'
 
 export async function sendTextTemplate ({
   to,
@@ -88,7 +88,7 @@ export async function sendTemplateRequest ({
 }: {
   query?: string
   config?: WsConfig
-}): Promise<any> {
+}): Promise<Templates | false> {
   const requestResponse = await sendRequest({
     id: 'businessId',
     path: 'message_templates',
@@ -99,9 +99,10 @@ export async function sendTemplateRequest ({
 
   if (!requestResponse.success) {
     console.error('Failed to get templates')
+    console.log(requestResponse.error)
     return false
   } else {
-    return requestResponse.response
+    return requestResponse.response as Templates
   }
 }
 
@@ -113,15 +114,15 @@ export async function getTemplates ({
   fields?: templateFields[]
   limit?: number
   config?: WsConfig
-} = {}): Promise<any> {
+} = {}): Promise<Templates> {
   const queryParams: {
     fields?: string
     limit?: string
   } = {}
   if (fields !== undefined) queryParams.fields = fields.join(',')
   if (limit !== undefined) queryParams.limit = limit.toString()
-  return await sendTemplateRequest({
+  return (await sendTemplateRequest({
     query: new URLSearchParams(queryParams).toString(),
     config
-  })
+  })) as Templates
 }

--- a/ws-cloud-api/src/templates.ts
+++ b/ws-cloud-api/src/templates.ts
@@ -5,6 +5,8 @@ import type {
   TemplateBodyParameter,
   TemplateHeaderParameter
 } from './types/messages'
+import { sendRequest } from './base'
+import type { templateFields } from './types/templates'
 
 export async function sendTextTemplate ({
   to,
@@ -76,6 +78,50 @@ export async function sendMediaTemplate ({
         ]
       }
     },
+    config
+  })
+}
+
+export async function sendTemplateRequest ({
+  query,
+  config
+}: {
+  query?: string
+  config?: WsConfig
+}): Promise<any> {
+  const requestResponse = await sendRequest({
+    id: 'businessId',
+    path: 'message_templates',
+    method: 'GET',
+    query,
+    config
+  })
+
+  if (!requestResponse.success) {
+    console.error('Failed to get templates')
+    return false
+  } else {
+    return requestResponse.response
+  }
+}
+
+export async function getTemplates ({
+  fields,
+  limit,
+  config
+}: {
+  fields?: templateFields[]
+  limit?: number
+  config?: WsConfig
+} = {}): Promise<any> {
+  const queryParams: {
+    fields?: string
+    limit?: string
+  } = {}
+  if (fields !== undefined) queryParams.fields = fields.join(',')
+  if (limit !== undefined) queryParams.limit = limit.toString()
+  return await sendTemplateRequest({
+    query: new URLSearchParams(queryParams).toString(),
     config
   })
 }

--- a/ws-cloud-api/src/test/templates.ts
+++ b/ws-cloud-api/src/test/templates.ts
@@ -50,12 +50,20 @@ const messageFunctions: Record<string, () => Promise<boolean>> = {
   'get-all': async () => {
     console.log(await getTemplates())
     return true
+  },
+  'get-names': async () => {
+    console.log(await getTemplates({ fields: ['name'] }))
+    return true
+  },
+  'get-2': async () => {
+    console.log(await getTemplates({ limit: 2 }))
+    return true
   }
 }
 
 if (templateType in messageFunctions) {
   messageFunctions[templateType]()
-    .then((success) => { if (success) console.log('Message sent') })
+    .then((success) => { if (success) console.log('Test end') })
     .catch(console.error)
 } else if (templateType === undefined) {
   console.error(

--- a/ws-cloud-api/src/test/templates.ts
+++ b/ws-cloud-api/src/test/templates.ts
@@ -58,6 +58,16 @@ const messageFunctions: Record<string, () => Promise<boolean>> = {
   'get-2': async () => {
     console.log(await getTemplates({ limit: 2 }))
     return true
+  },
+  'get-pagination': async () => {
+    const page1 = await getTemplates({ limit: 2 })
+    console.log('page1', page1)
+    const page2 = await getTemplates({
+      limit: 2,
+      after: page1.paging.cursors.after
+    })
+    console.log('page2', page2)
+    return true
   }
 }
 

--- a/ws-cloud-api/src/test/templates.ts
+++ b/ws-cloud-api/src/test/templates.ts
@@ -1,5 +1,9 @@
 import 'dotenv/config'
-import { sendMediaTemplate, sendTextTemplate } from '../../dist/templates'
+import {
+  sendMediaTemplate,
+  sendTextTemplate,
+  getTemplates
+} from '../../dist/templates'
 import { ParametersTypes } from '../../dist'
 
 const phoneNumberToTest = process.env.PHONE_NUMBER_RECIPIENT ?? ''
@@ -11,7 +15,7 @@ const messageFunctions: Record<string, () => Promise<boolean>> = {
     templateName: 'hello_world',
     language: 'en_US'
   }),
-  textParameters: async () => await sendTextTemplate({
+  'text-parameters': async () => await sendTextTemplate({
     to: phoneNumberToTest,
     templateName: 'hello_world_parameters',
     language: 'en',
@@ -26,7 +30,7 @@ const messageFunctions: Record<string, () => Promise<boolean>> = {
       }
     ]
   }),
-  mediaImage: async () => await sendMediaTemplate({
+  'media-image': async () => await sendMediaTemplate({
     to: phoneNumberToTest,
     templateName: 'hello_world_image',
     headerParameters: {
@@ -42,7 +46,11 @@ const messageFunctions: Record<string, () => Promise<boolean>> = {
       }
     ],
     language: 'en_US'
-  })
+  }),
+  'get-all': async () => {
+    console.log(await getTemplates())
+    return true
+  }
 }
 
 if (templateType in messageFunctions) {

--- a/ws-cloud-api/src/types/config.ts
+++ b/ws-cloud-api/src/types/config.ts
@@ -1,5 +1,6 @@
 export interface WsConfig {
   apiVersion?: string
   phoneNumberId?: string
+  businessId?: string
   token?: string
 }

--- a/ws-cloud-api/src/types/templates.ts
+++ b/ws-cloud-api/src/types/templates.ts
@@ -1,0 +1,14 @@
+export type templateFields = 'id' |
+'category' |
+'components' |
+'correct_category' |
+'cta_url_link_tracking_opted_out' |
+'language' |
+'library_template_name' |
+'message_send_ttl_seconds' |
+'name' |
+'previous_category' |
+'quality_score' |
+'rejected_reason' |
+'status' |
+'sub_category'

--- a/ws-cloud-api/src/types/templates.ts
+++ b/ws-cloud-api/src/types/templates.ts
@@ -12,3 +12,60 @@ export type templateFields = 'id' |
 'rejected_reason' |
 'status' |
 'sub_category'
+
+export interface Templates {
+  data: Template[]
+  paging: Paging
+}
+
+export interface Template {
+  name: string
+  components: Component[]
+  language: string
+  status: Status
+  category: Category
+  sub_category?: string
+  id: string
+  previous_category?: PreviousCategory
+}
+
+export type Category = 'MARKETING' | 'UTILITY'
+
+export interface Component {
+  type: ComponentType
+  text?: string
+  example?: Example
+  buttons?: Button[]
+  format?: Format
+}
+
+export interface Button {
+  type: ButtonType
+  text: string
+  url?: string
+}
+
+export type ButtonType = 'QUICK_REPLY' | 'URL'
+
+export interface Example {
+  body_text?: string[][]
+  header_handle?: string[]
+}
+
+export type Format = 'IMAGE' | 'TEXT' | 'VIDEO'
+
+export type ComponentType = 'BODY' | 'BUTTONS' | 'HEADER' | 'FOOTER'
+
+export type PreviousCategory = 'ISSUE_RESOLUTION' | 'APPOINTMENT_UPDATE' | 'MARKETING'
+
+export type Status = 'APPROVED'
+
+export interface Paging {
+  cursors: Cursors
+  next: string
+}
+
+export interface Cursors {
+  before: string
+  after: string
+}


### PR DESCRIPTION
This pull request includes several changes to add support for retrieving message templates from the WhatsApp Cloud API and refactoring the existing code to improve maintainability. The most important changes include adding the `getTemplates` function, refactoring `sendMessageRequest` to use a new `sendRequest` function, and updating test scripts.

### New Functionality:
* **Added `getTemplates` function**: This function retrieves a list of message templates from the WhatsApp Cloud API with optional parameters for fields, limit, pagination, and configuration. (`docs/src/templates/get.md`, `ws-cloud-api/src/templates.ts`) [[1]](diffhunk://#diff-357235fdcf4945b0cced9a2e47d24f95585c26339038e773f0b8f7a6da7b0d4bR1-R77) [[2]](diffhunk://#diff-b96e7a640164d47654e0479cda474c4460265ab047cd478a23d867471717966fR84-R136)

### Code Refactoring:
* **Refactored `sendMessageRequest` to use `sendRequest`**: The `sendMessageRequest` function now uses a new `sendRequest` function to handle HTTP requests, improving code modularity and reusability. (`ws-cloud-api/src/messaging.ts`)
* **Introduced `sendRequest` function**: This new function centralizes the HTTP request logic, making it easier to manage and update. (`ws-cloud-api/src/base.ts`)

### Configuration and Environment:
* **Updated `.env.example`**: Added `WS_BUSINESS_ID` to the environment configuration example file to support the new functionality. (`ws-cloud-api/.env.example`)

### Testing:
* **Renamed and updated test scripts**: The test script `sendTemplates.ts` was renamed to `templates.ts`, and new test cases were added for the `getTemplates` function. (`ws-cloud-api/src/test/templates.ts`) [[1]](diffhunk://#diff-c17909919b5fc9c473d02c540f7b2252b99b2778e69c3698f1b2754f5d37f83cL2-R6) [[2]](diffhunk://#diff-c17909919b5fc9c473d02c540f7b2252b99b2778e69c3698f1b2754f5d37f83cL14-R18) [[3]](diffhunk://#diff-c17909919b5fc9c473d02c540f7b2252b99b2778e69c3698f1b2754f5d37f83cL29-R33) [[4]](diffhunk://#diff-c17909919b5fc9c473d02c540f7b2252b99b2778e69c3698f1b2754f5d37f83cR49-R76)

### Documentation:
* **Updated VitePress configuration**: Added a new link to the `Get` templates documentation in the VitePress configuration. (`docs/.vitepress/config.mts`)

These changes enhance the functionality and maintainability of the codebase, making it easier to retrieve and manage message templates from the WhatsApp Cloud API.